### PR TITLE
Fix env loading and CLI output

### DIFF
--- a/GPT_Angel.py
+++ b/GPT_Angel.py
@@ -1,17 +1,17 @@
 # GPT_Angel.py  ── 椎名真晝 file_search 助手
 # ------------------------------------------------------------
-import os, json, time
+import os
+import json
+import time
 from dotenv import load_dotenv
 from openai import OpenAI
 
-# ====== 請依實際路徑調整 =================================================
-load_dotenv(r"D:/CYCU/113_DeepLearning/CODE/.env")
-    # .env 應含 OPENAI_API_KEY
-client = OpenAI()                                       # 自動抓環境變數金鑰
-# =========================================================================
-#hard code way
-#client = OpenAI(api_key="sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")
-# =========================================================================
+# 載入 .env 以取得 OPENAI_API_KEY。若路徑未指定，load_dotenv 會自動
+# 從當前目錄或其父層尋找 .env 檔。
+load_dotenv()
+client = OpenAI()  # 從環境變數讀取金鑰
+# 若需要硬編碼金鑰，可改為：
+# client = OpenAI(api_key="sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")
 
 # ---------- 參數（如需變更請只改這區） -------------------
 VECTOR_STORE_ID = "vs_6846de662bb08191a38989a9100f4170"  # 你的小說向量庫

--- a/GPT_Loser.py
+++ b/GPT_Loser.py
@@ -1,16 +1,16 @@
 # GPT_Russian.py  ── 八奈見同學 file_search 助手
 # ------------------------------------------------------------
-import os, json, time
-from dotenv import load_dotenv #hard code way 這行要註解掉
+import os
+import json
+import time
+from dotenv import load_dotenv
 from openai import OpenAI
 
-# ====== 請依實際路徑調整 =================================================
-load_dotenv(r"D:/CYCU/113_DeepLearning/CODE/.env")
-    # .env 應含 OPENAI_API_KEY
-client = OpenAI()                                       # 自動抓環境變數金鑰
-# =========================================================================
-#hard code way
-#client = OpenAI(api_key="sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")
+# 載入 .env 以取得 OPENAI_API_KEY，load_dotenv 會自動搜尋 .env 檔。
+load_dotenv()
+client = OpenAI()  # 從環境變數讀取金鑰
+# 若需要硬編碼金鑰，可改為：
+# client = OpenAI(api_key="sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")
 # =========================================================================
 
 # ---------- 參數（如需變更請只改這區） -------------------
@@ -140,5 +140,5 @@ if __name__ == "__main__":
             break
 
         reply = chat_as_Yanami(user_input)
-        print("八奈見杏菜", reply, "\n")
+        print("八奈見杏菜：", reply, "\n")
 # ====================== 互動式 CLI 結束 =================================

--- a/GPT_Russian.py
+++ b/GPT_Russian.py
@@ -1,16 +1,16 @@
 # GPT_Russian.py  ── 艾琳同學 file_search 助手
 # ------------------------------------------------------------
-import os, json, time
-from dotenv import load_dotenv #hard code way 這行要註解掉
+import os
+import json
+import time
+from dotenv import load_dotenv
 from openai import OpenAI
 
-# ====== 請依實際路徑調整 =================================================
-load_dotenv(r"D:/CYCU/113_DeepLearning/CODE/.env")
-    # .env 應含 OPENAI_API_KEY
-client = OpenAI()                                       # 自動抓環境變數金鑰
-# =========================================================================
-#hard code way
-#client = OpenAI(api_key="sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")
+# 載入 .env 以取得 OPENAI_API_KEY，load_dotenv 會自動搜尋 .env 檔。
+load_dotenv()
+client = OpenAI()  # 從環境變數讀取金鑰
+# 若需要硬編碼金鑰，可改為：
+# client = OpenAI(api_key="sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")
 # =========================================================================
 
 # ---------- 參數（如需變更請只改這區） -------------------
@@ -140,5 +140,5 @@ if __name__ == "__main__":
             break
 
         reply = chat_as_Ellie(user_input)
-        print("九條艾琳", reply, "\n")
+        print("九條艾琳：", reply, "\n")
 # ====================== 互動式 CLI 結束 =================================


### PR DESCRIPTION
## Summary
- remove hardcoded `.env` path and rely on `load_dotenv()` in each assistant module
- tweak CLI printouts for Ellie and Yanami

## Testing
- `python -m py_compile GPT_app.py GPT_Angel.py GPT_Russian.py GPT_Loser.py`

------
https://chatgpt.com/codex/tasks/task_e_684ebf90b39483229a316c6aceaf2a77